### PR TITLE
Add shell.nix for use with Nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let
+  # We pin to a specific nixpkgs commit for reproducibility.
+  # Last updated: 2025-03-31 15:00UTC.
+  pkgs =
+    import
+      (fetchTarball "https://github.com/NixOS/nixpkgs/archive/eb0e0f21f15c559d2ac7633dc81d079d1caf5f5f.tar.gz")
+      { };
+in
+pkgs.mkShell {
+  packages = [
+    (pkgs.python313.withPackages (
+      python-pkgs: with python-pkgs; [
+        # select Python packages here
+        mpmath
+        networkx
+        numpy
+        pillow
+        pyqt6
+        pyqt6-sip
+      ]
+    ))
+  ];
+}


### PR DESCRIPTION
This is basically a per-defined dev environment for use with the Nix package manager/NixOS.

Wont cause issues with any other dev tooling or packaging, just lets those who use Nix jump into running this a little quicker.

Some extra info if haven't seen nix before and you wanna learn more: https://www.youtube.com/watch?v=0YBWhSNTgV8